### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package is largely inspired by [suggested code on Stack Exchange](https://s
 ## Install
 Install this package through Composer:
 ```
-composer install coenjacobs/eloquent-composite-primary-keys
+composer require coenjacobs/eloquent-composite-primary-keys
 ```
 
 Make sure you have a database schema that supports composite primary keys, for example via a migration:


### PR DESCRIPTION
use `composer require` instead of `composer install` to ensure that we don't get the following error message:

```
Invalid argument coenjacobs/eloquent-composite-primary-keys. Use "composer require coenjacobs/eloquent-composite-primary-keys" instead to add packages to your composer.json.
```